### PR TITLE
skip input

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -11,6 +11,11 @@ on:
         type: string
         description: A stringified JSON array of the dist-tags to apply.
         required: true
+      skip:
+        type: boolean
+        description: Whether to skip the workflow or not.
+        required: false
+        default: false
     secrets:
       npm-token:
         description: The NPM token required to publish the package.
@@ -38,6 +43,7 @@ permissions:
 
 jobs:
   npm-publish-prerelease:
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-22.04
     outputs:
       package-name: ${{ steps.npm-publish.outputs.package-name }}

--- a/README.md
+++ b/README.md
@@ -23,10 +23,11 @@ then the version bump will result in "0.2.0-alpha.13".
 
 ## Inputs
 
-|   Name    | Required | Description                                                                                                                                                   |
-|:---------:|:--------:|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|   type    |   true   | The prerelease type. Either "premajor", "preminor", or "prepatch"                                                                                             |
-| dist-tags |   true   | A stringified JSON array of the dist-tags to apply. Because we are publishing prereleases, this is required and it *shouldn't include the "latest" dist-tag*. |
+|   Name    | Required | Description                                                                                                                                                               |
+|:---------:|:--------:|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|   type    |   true   | The prerelease type. Either "premajor", "preminor", or "prepatch"                                                                                                         |
+| dist-tags |   true   | A stringified JSON array of the dist-tags to apply. Because we are publishing prereleases, this is required and it *shouldn't include the "latest" dist-tag*.             |
+|   skip    |  false   | A boolean indicating whether to skip whether to skip the workflow. This is to workaround the required checks path issue when workflows are skipped. It defaults to false. |
 
 ## Secrets
 


### PR DESCRIPTION
- To workaround the known issue where GitHub required checks path isn't the
same when an inner workflow is skipped vs not skipped.
